### PR TITLE
Interactive

### DIFF
--- a/omsi/analysis/analysis_views.py
+++ b/omsi/analysis/analysis_views.py
@@ -205,7 +205,7 @@ class analysis_views(object):
                name, e.g., `omsi.analysis.multivariate_stat.omsi_nmf` or a name
                relative to the omis.analysis module, e.g, `multivariate_stat.omsi_nmf`.
 
-        :raises: Attribute error in case that the class cannot be restored.
+        :raises: NameError in case that the class cannot be restored.
         """
         import types
         import sys

--- a/omsi/dataformat/omsi_file/analysis.py
+++ b/omsi/dataformat/omsi_file/analysis.py
@@ -198,7 +198,8 @@ class omsi_analysis_manager(omsi_file_object_manager):
         :param analysis_identifier_string: The string used as identifier for the analysis.
         :type analysis_identifier_string: string
 
-        :returns: h5py obejct of the analysis or None in case the analysis is not found.
+        :returns: omsi_file_analysis object for the requested analysis. The function
+                      returns None in case the analysis object was not found.
         """
 
         # Iterate through all groups of the root folder

--- a/omsi/dataformat/omsi_file/format.py
+++ b/omsi/dataformat/omsi_file/format.py
@@ -3,6 +3,7 @@ This module defines the basic format for storing mass spectrometry imaging data,
 metadata, and analysis in HDF5 in compliance with OpenMSI file format.
 """
 import h5py
+import numpy as np
 
 
 class omsi_format_common(object):
@@ -137,6 +138,8 @@ class omsi_format_analysis(omsi_format_common):
     analysis_groupname = "analysis_"
     analysis_identifier = "analysis_identifier"
     analysis_type = "analysis_type"
+    analysis_class = "analysis_class"
+    analysis_class_pickle_np_dtype = np.dtype('uint8')
     analysis_parameter_group = "parameter"
     analysis_parameter_help_attr = 'help'
     analysis_runinfo_group = "runinfo"


### PR DESCRIPTION
Add support for performing interactive analysis as part of BASTet workflows. Workflows terminate and automatically restart when being blocked by incomplete interactive tasks. 

Add support to pickle analysis classes defined outside of BASTet as part of the storage. Previously this was only possible for functions wrapped via the bastet_analysis decorator or classes that were part of BASTet directly. 